### PR TITLE
feat: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
This pull request adds a new Dependabot configuration file, enabling automated dependency updates for npm packages in the repository. Dependabot will now check for updates on a weekly schedule and limit the number of open pull requests.

Dependency management automation:

* Added a `.github/dependabot.yml` file to configure Dependabot for npm, scheduling weekly checks and limiting to 5 open pull requests, with a "chore" prefix for commit messages.