### PR TITLE
fix: cards not visible on github pages

### DIFF
--- a/fix-css-paths-for-github-pages.js
+++ b/fix-css-paths-for-github-pages.js
@@ -1,0 +1,35 @@
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { GITHUB_PAGES_REPOSITORY } from "./github-pages.config.js";
+const OUT_DIR = join(import.meta.dirname, "out/_next/static/chunks");
+
+const fixPaths = async () => {
+  const files = await readdir(OUT_DIR);
+  const cssFiles = files.filter((f) => f.endsWith(".css"));
+
+  for (const file of cssFiles) {
+    const filePath = join(OUT_DIR, file);
+    let content = await readFile(filePath, "utf-8");
+
+    content = content
+      .replace(
+        /url\(\s*(['"]?)(\/textures\/)/g,
+        `url($1/${GITHUB_PAGES_REPOSITORY}/textures/`
+      )
+      .replace(
+        /url\(\s*(['"]?)(\/illustrations\/)/g,
+        `url($1/${GITHUB_PAGES_REPOSITORY}/illustrations/`
+      );
+
+    await writeFile(filePath, content);
+  }
+
+  console.log(`Fixed asset paths in ${cssFiles.length} CSS file(s)`);
+};
+
+try {
+  await fixPaths();
+} catch (error) {
+  console.error("Failed to fix CSS asset paths for GitHub Pages:", error);
+  process.exitCode = 1;
+}

--- a/github-pages.config.js
+++ b/github-pages.config.js
@@ -1,0 +1,1 @@
+export const GITHUB_PAGES_REPOSITORY = "obre";

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,17 @@
 import type { NextConfig } from "next";
+import { GITHUB_PAGES_REPOSITORY } from "./github-pages.config.js";
+
+const isProduction = process.env.NODE_ENV === "production";
+const basePath = isProduction ? `/${GITHUB_PAGES_REPOSITORY}` : "";
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
   output: "export",
+  basePath,
+  assetPrefix: isProduction ? `/${GITHUB_PAGES_REPOSITORY}/` : "",
+  env: {
+    NEXT_PUBLIC_BASE_PATH: basePath,
+  },
   images: {
     unoptimized: true,
   },

--- a/package.json
+++ b/package.json
@@ -2,11 +2,16 @@
   "name": "obre",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "next dev",
-    "preview": "npm run fix && npm run build && npx serve out",
+    "preview": "npm run fix && npm run build && node serve-preview-build.js",
     "prebuild": "npm run check",
     "build": "next build",
+    "postbuild": "node fix-css-paths-for-github-pages.js",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "format": "prettier . --write",

--- a/serve-preview-build.js
+++ b/serve-preview-build.js
@@ -1,0 +1,66 @@
+import { rmSync, mkdirSync, readdirSync, renameSync } from "node:fs";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { GITHUB_PAGES_REPOSITORY } from "./github-pages.config.js";
+
+const OUT_DIR = join(import.meta.dirname, "out");
+const NESTED_DIR = join(OUT_DIR, GITHUB_PAGES_REPOSITORY);
+
+// Clean up any leftover from a previous crashed run
+rmSync(NESTED_DIR, { recursive: true, force: true });
+
+// Get all files/folders in out/
+const entries = readdirSync(OUT_DIR);
+
+// Create the nested repository directory in out/ and move everything into it
+mkdirSync(NESTED_DIR, { recursive: true });
+for (const entry of entries) {
+  renameSync(join(OUT_DIR, entry), join(NESTED_DIR, entry));
+}
+
+console.log(`Serving at http://localhost:3000/${GITHUB_PAGES_REPOSITORY}`);
+
+// Start serve
+const serve = spawn("npx", ["serve", OUT_DIR, "-l", "3000"], {
+  stdio: "inherit",
+  shell: true,
+});
+
+// Restore original structure on exit
+const restore = () => {
+  if (restore.called) return;
+  restore.called = true;
+
+  try {
+    const nestedEntries = readdirSync(NESTED_DIR);
+    for (const entry of nestedEntries) {
+      renameSync(join(NESTED_DIR, entry), join(OUT_DIR, entry));
+    }
+  } catch {
+    // If NESTED_DIR does not exist or is already empty, ignore
+  }
+
+  try {
+    rmSync(NESTED_DIR, { recursive: true, force: true });
+  } catch {
+    // Best-effort cleanup
+  }
+};
+restore.called = false;
+
+const gracefulExit = (code = 0) => {
+  restore();
+  process.exit(code);
+};
+
+serve.on("close", restore);
+process.on("SIGINT", () => gracefulExit(0));
+process.on("SIGTERM", () => gracefulExit(0));
+process.on("uncaughtException", (error) => {
+  console.error("Uncaught exception:", error);
+  gracefulExit(1);
+});
+process.on("unhandledRejection", (reason) => {
+  console.error("Unhandled rejection:", reason);
+  gracefulExit(1);
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import TiltableCard, {
   type HoloEffectType,
   type MaskConfig,
 } from "@/components/atoms/TiltableCard/TiltableCard";
+import { asset } from "@/lib/basePath";
 import styles from "./page.module.css";
 
 const effects: (HoloEffectType | undefined)[] = [
@@ -14,11 +15,11 @@ const effects: (HoloEffectType | undefined)[] = [
 ];
 
 const maskConfigs: Record<HoloEffectType, MaskConfig> = {
-  holo: { src: "/illustrations/1/mask.png", effect: "holo" },
-  cosmos: { src: "/illustrations/1/mask.png", effect: "cosmos" },
-  rainbow: { src: "/illustrations/1/mask.png", effect: "rainbow" },
-  reverse: { src: "/illustrations/1/mask.png", effect: "reverse" },
-  shiny: { src: "/illustrations/1/mask.png", effect: "shiny" },
+  holo: { src: asset("/illustrations/1/mask.png"), effect: "holo" },
+  cosmos: { src: asset("/illustrations/1/mask.png"), effect: "cosmos" },
+  rainbow: { src: asset("/illustrations/1/mask.png"), effect: "rainbow" },
+  reverse: { src: asset("/illustrations/1/mask.png"), effect: "reverse" },
+  shiny: { src: asset("/illustrations/1/mask.png"), effect: "shiny" },
 };
 
 export default function Home() {
@@ -28,7 +29,7 @@ export default function Home() {
         {effects.map((effect) => (
           <div key={effect ?? "none"} className={styles.cardWrapper}>
             <TiltableCard
-              src="/illustrations/1/image.png"
+              src={asset("/illustrations/1/image.png")}
               masks={effect ? maskConfigs[effect] : undefined}
             />
             <span className={styles.effectLabel}>{effect ?? "no effect"}</span>

--- a/src/lib/basePath.ts
+++ b/src/lib/basePath.ts
@@ -1,0 +1,3 @@
+export const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+
+export const asset = (path: string) => `${basePath}${path}`;


### PR DESCRIPTION
This pull request introduces a set of changes to ensure the application works correctly when deployed to GitHub Pages, which requires all asset and routing paths to be prefixed with the repository name. The changes include updates to build scripts, configuration files, and asset path handling in both frontend code and static CSS files. The most important changes are summarized below:

**GitHub Pages Compatibility and Asset Path Handling**

* Added a new configuration constant `GITHUB_PAGES_REPOSITORY` to centralize the repository name for path prefixing. (`github-pages.config.js`)
* Updated `next.config.ts` to set `basePath` and `assetPrefix` dynamically based on the environment, and exposed `NEXT_PUBLIC_BASE_PATH` for use in client-side code.
* Introduced a utility (`src/lib/basePath.ts`) and refactored asset references in `src/app/page.tsx` to use the correct base path for images and masks. [[1]](diffhunk://#diff-1ceea855d69ef73d5fb68a0f8819958caae0642fc70c4b1f589729fe8e6c1e2eR1-R3) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR5) [[3]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL17-R22) [[4]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL31-R32)

**Build and Preview Workflow Improvements**

* Added a post-build script (`fix-css-paths-for-github-pages.js`) to rewrite asset URLs in CSS files to include the repository prefix, ensuring correct asset loading on GitHub Pages.
* Replaced the preview script with a new workflow (`serve-preview-build.js`) that nests the exported build under the repository name (as GitHub Pages expects) and serves it locally for accurate previewing.
* Updated `package.json` to set the project as an ES module, specify Node.js version requirements, and wire up the new build and preview scripts.